### PR TITLE
Using decode('utf-8') to allow for Python 3 compatibility when handling API response

### DIFF
--- a/heywatch/job.py
+++ b/heywatch/job.py
@@ -18,4 +18,4 @@ def submit(config_content, **kwargs):
 
   response, content = h.request(heywatch_url + '/api/v1/job', 'POST', body=config_content, headers=headers)
 
-  return json.loads(content)
+  return json.loads(content.decode('utf-8'))


### PR DESCRIPTION
Small change that is backward-compatible for Python 2 but adds Python 3 compatibility.

In Python 3, we get the error `the JSON object must be str, not 'bytes'` on the following line:

``` python
return json.loads(content)
```